### PR TITLE
logged exact model checkpoint location

### DIFF
--- a/main_bert.py
+++ b/main_bert.py
@@ -28,6 +28,7 @@ def main() -> None:
         experiment_name=config.experiment_name,
     )
     logger.log_hyperparams(config)
+    logger.log_hyperparams({"model_checkpoint_path": save_path})
 
     save_model_callback = ModelCheckpoint(
         os.path.join(save_path, "{epoch}-{val_loss:.2f}"), monitor="val_loss"


### PR DESCRIPTION
Hintergrund: wemmer vome gspeicherete model will predicte muemer de pfad dezue ageh, de pfad esch so öppe some_path/bert-baseline/some_date/some_model.ckpt s problem woni gha han esch ich han us de comet infos wenns fertig worde esch und wie langs glofe esch müesse rekonstruiere was "some_date" genau gsi esch. Da mer das ersch bi runtime wüssed hanis jetzt eifach no uf comet gloggt dasmers zueghörige file schnell findet